### PR TITLE
demo: Run code generators as module commands

### DIFF
--- a/demo/gotran2c/Makefile
+++ b/demo/gotran2c/Makefile
@@ -6,6 +6,8 @@ libfile = libdemo.so
 CFLAGS = -Wall -O3 -ffast-math -march=native
 LDLIBS = -lm
 
+gotran_generator = python -m gotran gotran2c
+
 all: $(executable) $(libfile)
 #all: $(libfile)
 $(executable): demo.o
@@ -17,7 +19,7 @@ $(libfile): $(sources) tentusscher_panfilov_2006_M_cell.h
 #
 demo.o: tentusscher_panfilov_2006_M_cell.h
 tentusscher_panfilov_2006_M_cell.h: tentusscher_panfilov_2006_M_cell.ode
-	gotran2c $< --solvers.explicit_euler.generate=1 --solvers.rush_larsen.generate=1 --code.body.use_enum=1 --output=$@
+	$(gotran_generator) $< --solvers.explicit_euler.generate=1 --solvers.rush_larsen.generate=1 --code.body.use_enum=1 --output=$@
 
 clean:
 	$(RM) $(libfile)

--- a/demo/gotran2c/README.md
+++ b/demo/gotran2c/README.md
@@ -8,7 +8,7 @@ To illustrate the usage we will use the
 To generate C code from the ode file, we use the following command:
 
 ```
-gotran2c tentusscher_panfilov_2006_M_cell.ode --solvers.explicit_euler.generate=1 --solvers.rush_larsen.generate=1 --code.body.use_enum=1
+python -m gotran gotran2c tentusscher_panfilov_2006_M_cell.ode --solvers.explicit_euler.generate=1 --solvers.rush_larsen.generate=1 --code.body.use_enum=1
 ```
 
 The first two arguments specify that we want to generate solver functions for the

--- a/demo/gotran2julia/README.md
+++ b/demo/gotran2julia/README.md
@@ -8,7 +8,7 @@ your ODE. To illustrate the usage we will use the
 To generate the relevant julia
 
 ```
-gotran2julia tentusscher_panfilov_2006_M_cell.ode
+python -m gotran gotran2julia tentusscher_panfilov_2006_M_cell.ode
 ```
 
 This will create a new file called
@@ -29,7 +29,7 @@ a plot of the membrane potential and the Kr current.
 
 Note that by typing
 ```
-gotran2py --help
+python -m gotran gotran2julia --help
 ```
 
 you can get all the options for codegeneration.

--- a/demo/gotran2opencl/Makefile
+++ b/demo/gotran2opencl/Makefile
@@ -3,7 +3,7 @@ MODEL=tentusscher_panfilov_2006_M_cell
 all: $(MODEL).cl $(MODEL).py
 
 $(MODEL).cl: $(MODEL).ode
-	gotran2opencl $< --solvers.explicit_euler.generate=1 --solvers.explicit_euler.function_name=FE --solvers.generalized_rush_larsen.generate=1 --solvers.generalized_rush_larsen.function_name=GRL1 --code.body.use_enum=1 --output=$@
+	python -m gotran gotran2opencl $< --solvers.explicit_euler.generate=1 --solvers.explicit_euler.function_name=FE --solvers.generalized_rush_larsen.generate=1 --solvers.generalized_rush_larsen.function_name=GRL1 --code.body.use_enum=1 --output=$@
 
 $(MODEL).py: $(MODEL).ode
 	gotran2py $<

--- a/demo/gotran2py/README.md
+++ b/demo/gotran2py/README.md
@@ -7,7 +7,7 @@ ode-file. To illustrate the usage we will use the
 To generate a python module type
 
 ```
-gotran2py tentusscher_panfilov_2006_M_cell.ode
+python -m gotran gotran2py tentusscher_panfilov_2006_M_cell.ode
 ```
 
 This will create a new file called
@@ -27,7 +27,7 @@ a plot of the membrane potential and the Kr current.
 
 Note that by typing
 ```
-gotran2py --help
+python -m gotran gotran2py --help
 ```
 
 you can get all the options for codegeneration.


### PR DESCRIPTION
The demos had to be updated as we no longer install executable scripts for `gotran2c` and the other code generators.