### PR TITLE
State symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,12 @@ jobs:
       - name: Install package
         run: |
           python -m pip install -e ".[test,plot]"
-      - name: Test with pytest
-        run: |
-          python -m pytest
+      - name: Run tests
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 5
+          command: python -m pytest
       - name: Coverage report
         if: matrix.python-version == '3.10'
         run: |

--- a/gotran/model/ode.py
+++ b/gotran/model/ode.py
@@ -149,10 +149,10 @@ class ODE(ODEComponent):
 
     @property
     def state_symbols(self):
-        return [s.name for s in self.states]
+        return [s.name for s in self.full_states]
 
     def state_values(self):
-        return [s.value for s in self.states]
+        return [s.value for s in self.full_states]
 
     @property
     def intermediate_symbols(self):


### PR DESCRIPTION
For some reason, [`goss`](https://github.com/ComputationalPhysiology/goss) uses `ode.full_states` rather than `ode.states` to generate code. Since `ode.full_states` and `ode.states` may be identical but in different order, this might result in a wrong index being used if you rely on the order to be the same. Here we just simple make sure that the `state_symbols` and `state_values` uses the `full_states` in order to make things a bit more consistent.